### PR TITLE
Heroku

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
         ],
         "linebreak-style": [
             "error",
-            "windows"
+            "unix"
         ],
         "quotes": [
             "error",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,9 @@
     "experimentalDecorators": true,
     "removeComments": false,
     "noImplicitAny": false
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "typings/node"
+  ]
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,3 +1,2 @@
 /// <reference path="globals/core-js/index.d.ts" />
 /// <reference path="globals/jasmine/index.d.ts" />
-/// <reference path="globals/node/index.d.ts" />


### PR DESCRIPTION
ignoring node typings to resolve `Duplicate identifier` errors on Heroku
